### PR TITLE
fix(USER): make sure klar would not run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,5 @@ LABEL name="klar" \
       release=${IMAGE_VERSION} \
       summary="Integration of Clair and Docker Registry" \
       description="Simple tool to analyze images stored in a private or public Docker registry for security vulnerabilities using Clair"
+
+USER 1000


### PR DESCRIPTION
Following up on https://github.com/Portshift/kubei/issues/57

Making sure klar would not run as root, would spare us from having to set a securityContext or some PodSecurityPolicy, forcing that user not to be root.
